### PR TITLE
11-connectButtonPressEvent-does-not-properly-connect

### DIFF
--- a/src/Mars-Gtk/GtkWidget.class.st
+++ b/src/Mars-Gtk/GtkWidget.class.st
@@ -171,7 +171,7 @@ GtkWidget >> connectButtonPressEvent: aBlock [
 	"connects to button-press-event signal 
 	 aBlock needs to answer a boolean to stop or not event propagation"
 
-	^ GButtonPressEventCallback do: aBlock	
+	^ (GButtonPressEventCallback do: aBlock) connectTo: self	
 
 ]
 


### PR DESCRIPTION
fix connectButtonPressEvent:
fixes #11